### PR TITLE
Myanmar: Separate names

### DIFF
--- a/lib/member.rb
+++ b/lib/member.rb
@@ -6,7 +6,7 @@ class String
   end
 end
 
-class MemberFormatter
+class Member
   include FieldSerializer
 
   def initialize(member)

--- a/lib/member_formatter.rb
+++ b/lib/member_formatter.rb
@@ -18,7 +18,7 @@ class MemberFormatter
   end
 
   field :name do
-    names[0].tidy
+    names.first.tidy
   end
 
   field :other_name do

--- a/lib/member_formatter.rb
+++ b/lib/member_formatter.rb
@@ -22,7 +22,7 @@ class MemberFormatter
   end
 
   field :alternate_names do
-    names[1].tidy unless names[1].nil?
+    names.drop(1).map(&:tidy).join(';') unless names[1].nil?
   end
 
   field :cell do

--- a/lib/member_formatter.rb
+++ b/lib/member_formatter.rb
@@ -21,7 +21,7 @@ class MemberFormatter
     names.first.tidy
   end
 
-  field :other_name do
+  field :alternate_names do
     names[1].tidy unless names[1].nil?
   end
 

--- a/lib/member_formatter.rb
+++ b/lib/member_formatter.rb
@@ -12,7 +12,11 @@ class MemberFormatter
   end
 
   field :name do
-    person[:name]
+    names[0]
+  end
+
+  field :other_names do
+    names[1]
   end
 
   field :cell do
@@ -53,10 +57,6 @@ class MemberFormatter
 
   field :sort_name do
     person[:sort_name]
-  end
-
-  field :other_names do
-    person[:other_names].join(';')
   end
 
   field :gender do
@@ -102,6 +102,10 @@ class MemberFormatter
   private
 
   attr_reader :member
+
+  def names
+    person[:name].split('(or)')
+  end
 
   def person
     member[:person]

--- a/lib/member_formatter.rb
+++ b/lib/member_formatter.rb
@@ -1,5 +1,11 @@
 require 'field_serializer'
 
+class String
+  def tidy
+    gsub(/[[:space:]]+/, ' ').strip
+  end
+end
+
 class MemberFormatter
   include FieldSerializer
 
@@ -12,11 +18,11 @@ class MemberFormatter
   end
 
   field :name do
-    names[0]
+    names[0].tidy
   end
 
-  field :other_names do
-    names[1]
+  field :other_name do
+    names[1].tidy unless names[1].nil?
   end
 
   field :cell do

--- a/lib/members.rb
+++ b/lib/members.rb
@@ -22,7 +22,7 @@ class Members
 
   def format(mems)
     mems.map do |mem|
-      MemberFormatter.new(mem).to_h
+      Member.new(mem).to_h
     end
   end
 

--- a/lib/members.rb
+++ b/lib/members.rb
@@ -11,7 +11,9 @@ class Members
   end
 
   def to_a
-    format(all_members)
+    mems.map do |mem|
+      Member.new(mem).to_h
+    end
   end
 
   def json_for(url)
@@ -19,12 +21,6 @@ class Members
   end
 
   private
-
-  def format(mems)
-    mems.map do |mem|
-      Member.new(mem).to_h
-    end
-  end
 
   def all_members
     r = []


### PR DESCRIPTION
There are multiple occurrences of two names being recorded in the name field. For example, in the data for the membership with the id of "59143f6e3cf2461789e4c78bc54afe74", the name of the person is: "U Phye Ral (or) U Myint Than Htoo”. ( http://api.openhluttaw.org/en/memberships?page=2 )

This commit separates the two parts of the string at 'or'. The first part is treated as the 'official' name. The second part is stored in `:other_name`.