### PR TITLE
Call member#to_h when writing to DB

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -9,6 +9,6 @@ require_relative 'lib/members.rb'
 members_url = 'http://api.openhluttaw.org/en/memberships'
 members = Members.new(members_url).to_h[:members_of_the_lower_house]
 
-members.map do |member|
+members.each do |member|
   ScraperWiki.save_sqlite([:id], member.to_h)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,5 +10,5 @@ members_url = 'http://api.openhluttaw.org/en/memberships'
 members = Members.new(members_url).to_h[:members_of_the_lower_house]
 
 members.map do |member|
-  ScraperWiki.save_sqlite([:id], member)
+  ScraperWiki.save_sqlite([:id], member.to_h)
 end


### PR DESCRIPTION
The scraper is currently failing when writing to the database because it is passing Member objects instead of hashes into `ScraperWiki.save_sqlite`

Members holds a list of Member objects in its :members_of_the_lower_house
field. #to_h needs to be called on these objects when writing to the
database.