### PR TITLE
Require open-uri in scraper instead of Members

### DIFF
--- a/lib/members.rb
+++ b/lib/members.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
-require 'open-uri'
-require 'open-uri/cached'
 require 'json'
 require 'field_serializer'
 require_relative 'member'
-
-OpenURI::Cache.cache_path = '.cache'
 
 class Members
   include FieldSerializer

--- a/scraper.rb
+++ b/scraper.rb
@@ -3,8 +3,11 @@
 # frozen_string_literal: true
 
 require 'scraperwiki'
-
 require_relative 'lib/members.rb'
+
+require 'open-uri/cached'
+OpenURI::Cache.cache_path = '.cache'
+# require 'scraped_page_archive/open-uri'
 
 members_url = 'http://api.openhluttaw.org/en/memberships'
 


### PR DESCRIPTION
This is not a dependency of the class. It should be required in `scraper.rb` instead.

This is a step towards importing the new term. Part of: https://github.com/everypolitician/everypolitician-data/issues/4161