### PR TITLE
Configure Travis to run ensure-regression-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.3.3
 sudo: false
 cache: bundler
+script:
+  - bundle exec rake
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/v0.1.0/ensure-regression-tests)


### PR DESCRIPTION
This PR configures Travis to run a the ensure-regression-test script. This script ensures that PRs include passing tests which fail against master. The script skips branches that include the word 'refactor'. 

Issue: https://github.com/everypolitician/everypolitician/issues/588
