### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -11,6 +11,6 @@ OpenURI::Cache.cache_path = '.cache'
 
 members_url = 'http://api.openhluttaw.org/en/memberships'
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 data = Members.new(members_url).members_of_the_lower_house.map(&:to_h)
 ScraperWiki.save_sqlite([:id], data)


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593